### PR TITLE
VC update code cleanup; move SetVCCueCardsArrows call to clbkVCRedraw…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.cpp
@@ -1170,6 +1170,8 @@ void Saturn::initSaturn()
 	coascdridx = -1;
 	coascdrreticleidx = -1;
 	cmvccuecardsarrowsidx = -1;
+	hcmPointingArrowidx = -1;
+	LESMeshidx = -1;
 
 	vcmesh = NULL;
 	vis = NULL;
@@ -1218,6 +1220,7 @@ void Saturn::initSaturn()
 	VCSeatsfolded = false;
 
 	COASreticlevisible = false;
+	ViewCueCardArrows = false;
 
 	CurrentFuelWeight = 0;
 	LastFuelWeight = numeric_limits<double>::infinity(); // Ensure update at first opportunity
@@ -1239,6 +1242,8 @@ void Saturn::initSaturn()
 	MissionTimer_GlareshadeState.Set(AnimState::OPENING, 1.0);
 	Sextant_EyepieceState.Set(AnimState::OPENING, 1.0);
 	Telescope_EyepieceState.Set(AnimState::OPENING, 1.0);
+
+	wasteDisposalKnob = NULL;
 
 	// call only once 
 	if (!InitSaturnCalled) {
@@ -1583,7 +1588,6 @@ void Saturn::clbkPreStep(double simt, double simdt, double mjd)
 	CheckBPC_SideHatchCover();
 //	UpdatePointingArrow();
 //	InitFDAICustomCamera();
-	SetVCCueCardsArrows();
 
 	//
 	// We die horribly if you set 100x or higher acceleration during launch.
@@ -3724,13 +3728,16 @@ int Saturn::clbkConsumeBufferedKey(DWORD key, bool down, char *kstate) {
 		if (down) {
 			switch (key) {
 			case OAPI_KEY_H:
-				if (ViewCueCardArrows == true) {
-					ViewCueCardArrows = false;
+				if (InVC && oapiCameraInternal())
+				{
+					if (ViewCueCardArrows == true) {
+						ViewCueCardArrows = false;
+					}
+					else {
+						ViewCueCardArrows = true;
+					}
+					return 1;
 				}
-				else {
-					ViewCueCardArrows = true;
-				}
-				return 1;
 			}
 		}
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturn.h
@@ -1306,7 +1306,6 @@ public:
 	void DoMeshAnimation(AnimState &, UINT &, double, double);
 
 	void UpdatePointingArrow();
-	PanelSwitchItem *nextActiveSwitch = nullptr;
 	void CheckBPC_SideHatchCover();
 	void UpdateSideHatchClickspots(const VECTOR3 &ofs);
 	void UpdateForwardHatchClickspots(const VECTOR3 &ofs);
@@ -4270,7 +4269,7 @@ protected:
 #endif
 
 //	CAMERAHANDLE hFDAICam = NULL;
-	SURFHANDLE srfFDAICamTexture;
+//	SURFHANDLE srfFDAICamTexture;
 //	SURFHANDLE hFDAISurf;
 
 //	void InitFDAICustomCamera(void);

--- a/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_csm/saturnvc.cpp
@@ -2196,6 +2196,7 @@ bool Saturn::clbkVCRedrawEvent (int id, int event, SURFHANDLE surf)
 	case AID_CMVC_POINTINGARROW:
 	{
 		UpdatePointingArrow();
+		SetVCCueCardsArrows();
 	}
 
 	case AID_VC_CUE_CARDS_LIGHTING:

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.cpp
@@ -1321,7 +1321,6 @@ void LEM::SetAnimations(double simdt) {
 void LEM::clbkPreStep (double simt, double simdt, double mjd) {
 
 	SetAnimations(simdt);
-//	UpdatePointingArrow();
 
 	if (CheckPanelIdInTimestep) {
 		oapiSetPanel(PanelId);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/LEM.h
@@ -552,7 +552,6 @@ public:
 	void SetAnimations(double);
 
 	void UpdatePointingArrow();
-	PanelSwitchItem *nextActiveSwitch = nullptr;
 
 	//
 	// VISHANDLE


### PR DESCRIPTION
…Event; only check the key combination for viewing cue cards (LCTRL + H) when in the VC, thereby not blocking the 2D panel HUD key combination